### PR TITLE
Release notes (python-net): HTML 26.4.0

### DIFF
--- a/content/en/html/python-net/release-notes/2026/aspose-html-for-python-via-dotnet-26.4.0-release-notes.md
+++ b/content/en/html/python-net/release-notes/2026/aspose-html-for-python-via-dotnet-26.4.0-release-notes.md
@@ -1,0 +1,40 @@
+---
+id: "aspose-html-for-python-via-dotnet-26-4-release-notes"
+slug: "aspose-html-for-python-via-dotnet-26-4-release-notes"
+linktitle: "Aspose.HTML for Python via .NET 26.4 Release Notes"
+title: "Aspose.HTML for Python via .NET 26.4 Release Notes"
+weight: 90
+description: "Aspose.HTML for Python via .NET 26.4 Release Notes - the latest updates and fixes."
+type: "repository"
+layout: "release"
+hideChildren: false
+toc: false
+family_listing_page_title: "Aspose.HTML for Python via .NET 26.4 Release Notes"
+menuItemWithNoContent: false
+---
+
+{{% alert color="primary" %}}
+This page contains release notes information for Aspose.HTML for Python via .NET 26.4.
+{{% /alert %}}
+
+As per the regular monthly update process of all APIs being offered by Aspose, we are honored to announce the April release of Aspose.HTML for Python via .NET.
+
+### Release Notes
+
+This release includes targeted april improvements focused on conversion stability, rendering correctness, and standards compliance.
+
+**Package references**<br>
+Aspose.HTML for Python via .NET 26.4.0 [NuGet](https://www.nuget.org/packages/Aspose.Html)<br>
+Aspose.HTML.Drawing for .NET 26.4.0 [NuGet](https://www.nuget.org/packages/Aspose.Html.Drawing)<br>
+Aspose.HTML for Python via .NET  26.4.0 [PyPI](https://pypi.org/project/aspose-html-net/)
+
+## **Improvements and Changes**
+
+| **Key** | **Summary** | **Category** |
+| ------------ | -------------------------------------------------------------------------------------- | ------------ |
+| HTMLNET-6670 | Fixed an ArgumentException that could occur when processing auto values during HTML layout. | Bug |
+| HTMLNET-6967 | Improved tagged PDF generation for nested and definition lists, ensuring correct structuretree mapping and accessibility semantics. | Bug |
+| HTMLNET-6957 | Fixed PDF rendering problems when drawing complex borders and paths. | Bug |
+| HTMLNET-6287 | Enhanced Flex layout handling and standards compliance for complex sizing and alignment scenarios. | Bug |
+| HTMLNET-7045 | Fixed tagged PDF link and table-header semantics to improve PDF/UA accessibility compliance. | Bug |
+| HTMLNET-6851 | Added support for named @page rules with mixed page sizes in the generated output. | Feature |


### PR DESCRIPTION
Auto-generated release notes for HTML 26.4.0 (python-net).