### PR TITLE
Release notes (python-net): SVG 26.4.0

### DIFF
--- a/content/en/svg/python-net/release-notes/2026/aspose-svg-for-python-via-dotnet-26.4.0-release-notes.md
+++ b/content/en/svg/python-net/release-notes/2026/aspose-svg-for-python-via-dotnet-26.4.0-release-notes.md
@@ -1,0 +1,33 @@
+---
+id: "aspose-svg-for-python-via-dotnet-26-4-release-notes"
+slug: "aspose-svg-for-python-via-dotnet-26-4-release-notes"
+linktitle: "Aspose.SVG for Python via .NET 26.4 Release Notes"
+title: "Aspose.SVG for Python via .NET 26.4 Release Notes"
+weight: 47
+description: "Aspose.SVG for Python via .NET 26.4 Release Notes - the latest updates and fixes."
+type: "repository"
+layout: "release"
+hideChildren: false
+toc: false
+family_listing_page_title: "Aspose.SVG for Python via .NET 26.4 Release Notes"
+menuItemWithNoContent: false
+---
+
+{{% alert color="primary" %}}
+This page contains release notes information for Aspose.SVG for Python via .NET 26.4.
+{{% /alert %}}
+
+As per the regular monthly update process of all APIs being offered by Aspose, we are honored to announce the April release of Aspose.SVG for Python via .NET.
+
+### Release Notes
+
+The April update for Aspose.SVG for Python via .NET carries refinements affecting rendering consistency and overall stability.
+
+**Package references**<br>
+Aspose.SVG for Python via .NET 26.4.0 [NuGet](https://www.nuget.org/packages/Aspose.Svg)<br>
+Aspose.SVG for Python via .NET  26.4.0 [PyPI](https://pypi.org/project/aspose-svg-net/)
+
+## **Improvements and Changes**
+
+- SVG documents with complex borders or paths now render correctly when exported to PDF.
+- SVG rendering now handles embedded HTML elements with "auto" layout values without throwing an ArgumentException.


### PR DESCRIPTION
Auto-generated release notes for SVG 26.4.0 (python-net).