### PR TITLE
Add Aspose.LLM for .NET 26.5.0 release notes

### DIFF
--- a/content/en/llm/net/release-notes/2026/aspose-llm-for-net-26-5-0-release-notes.md
+++ b/content/en/llm/net/release-notes/2026/aspose-llm-for-net-26-5-0-release-notes.md
@@ -7,32 +7,18 @@ weight: 10
 description: "Aspose.LLM for .NET 26.5.0 Release Notes - the latest updates and fixes."
 type: "repository"
 layout: "release"
-family_listing_page_title: "Aspose.LLM for .NET 26.5.0 Release Notes"
-keywords: "Aspose.LLM for .NET 26.5.0 Release Notes, Aspose.LLM for .NET 26.5.0 updates and fixes"
 ---
 
-{{% alert color="primary" %}}
+Aspose.LLM for .NET includes externally visible product updates for this release.
 
-This page contains release notes for [Aspose.LLM for .NET 26.5.0](https://www.nuget.org/packages/Aspose.LLM/26.5.0).
+## Improvements
 
-{{% /alert %}}
+- Added CPU-friendly twin presets for all 14 new model variants, enabling CPU-only inference with optimized memory usage and batch sizes.
 
-Aspose.LLM for .NET 26.5.0 focuses on updated runtime compatibility, improved multimodal behavior, and more reliable chat session initialization.
+## Fixes
 
-## **Improvements and Changes**
-
-| **Summary** | **Category** |
-| :- | :- |
-| Updated the default bundled `llama.cpp` runtime used by the library. | Enhancement |
-| Improved compatibility with newer multimodal runtime behavior. | Enhancement |
-| Improved runtime package handling for macOS ARM64 `.tar.gz` assets. | Enhancement |
-| Improved session startup so preset-captured chat parameters are applied more consistently when creating a new session. | Enhancement |
-| Fixed a session initialization issue where preset-captured `ChatParameters` could be ignored when creating a new session. | Bug |
-| Fixed compatibility issues that could affect multimodal decoding with updated runtime packages. | Bug |
-| Fixed runtime asset parsing for additional archive naming variants. | Bug |
-
-## **Public API and Backwards Incompatible Changes**
-
-- Existing preset-based initialization remains supported.
-- Existing chat session and persistence APIs remain supported.
-- The default runtime package was updated without requiring changes to the common chat APIs.
+- Fixed Qwen25VL3B preset by switching from UD-IQ2_XXS (2-bit Unsloth Dynamic) quant to Q4_K_M quant.
+- Fixed Phi4 preset by retargeting from the bartowski repository (returning 401) to the unsloth mirror.
+- Improved error message for model loading failures in MultimodalModel to clarify root causes and dispel misattribution to multimodal routing.
+- Added defensive cleanup of orphaned .download files at start of download to prevent IOException on Windows when previous interrupted attempts left partial files.
+- Fixed DefaultFormatter to stop truncating responses at the first blank line by removing the artificial '\n\n' EOS token sentinel and relying on native llama.cpp.


### PR DESCRIPTION
Autonomous release notes publication for Aspose.LLM for .NET 26.5.0.