### PR TITLE
Bump checkout v5 + actions-hugo v3 across 27 stage builds (Node 20)

### DIFF
--- a/.github/workflows/stage-build-3d.yml
+++ b/.github/workflows/stage-build-3d.yml
@@ -35,13 +35,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-barcode.yml
+++ b/.github/workflows/stage-build-barcode.yml
@@ -35,13 +35,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-cad.yml
+++ b/.github/workflows/stage-build-cad.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-cells.yml
+++ b/.github/workflows/stage-build-cells.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-corporate.yml
+++ b/.github/workflows/stage-build-corporate.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-diagram.yml
+++ b/.github/workflows/stage-build-diagram.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-drawing.yml
+++ b/.github/workflows/stage-build-drawing.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-email.yml
+++ b/.github/workflows/stage-build-email.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-finance.yml
+++ b/.github/workflows/stage-build-finance.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-font.yml
+++ b/.github/workflows/stage-build-font.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-gis.yml
+++ b/.github/workflows/stage-build-gis.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-html.yml
+++ b/.github/workflows/stage-build-html.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-imaging.yml
+++ b/.github/workflows/stage-build-imaging.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-llm.yml
+++ b/.github/workflows/stage-build-llm.yml
@@ -22,13 +22,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-note.yml
+++ b/.github/workflows/stage-build-note.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-ocr.yml
+++ b/.github/workflows/stage-build-ocr.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-omr.yml
+++ b/.github/workflows/stage-build-omr.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-page.yml
+++ b/.github/workflows/stage-build-page.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-pdf.yml
+++ b/.github/workflows/stage-build-pdf.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-psd.yml
+++ b/.github/workflows/stage-build-psd.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-pub.yml
+++ b/.github/workflows/stage-build-pub.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-slides.yml
+++ b/.github/workflows/stage-build-slides.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-svg.yml
+++ b/.github/workflows/stage-build-svg.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-tasks.yml
+++ b/.github/workflows/stage-build-tasks.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-tex.yml
+++ b/.github/workflows/stage-build-tex.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-words.yml
+++ b/.github/workflows/stage-build-words.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 

--- a/.github/workflows/stage-build-zip.yml
+++ b/.github/workflows/stage-build-zip.yml
@@ -32,13 +32,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
           submodules: true  # Fetch Hugo themes
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
           hugo-version: '0.101.0'
 


### PR DESCRIPTION
## What
Bumps two Node-based actions across the remaining 27 `stage-build-*.yml` workflows:
- `actions/checkout@v2` → `@v5`
- `peaceiris/actions-hugo@v2` → `@v3`

Replicates the change already merged for `stage-build-total.yml` in #878.

## Why
GitHub Actions Node 16/20 runtime deprecation: old action versions are forced onto
Node 24 on 2026-06-16 and the old runtime is removed 2026-09-16. checkout@v5 and
actions-hugo@v3 both run on Node 24 and accept the same inputs (submodules,
fetch-depth, hugo-version '0.101.0').

## Scope
- Exactly 2 lines changed per file (27 files, 54/54). `stage-build-total.yml` already done.
- Out of scope (untouched): `swimlane/s3-upload-file-action@main` (Step D — replace with
  `aws s3 cp`), and the Docker actions (jakejarvis, zdurham, chetan).

## Verification
- `actionlint` clean across all 28 stage-build workflows.
- Manual `workflow_dispatch` on this branch — all green:
  - `staging-llm` (odd layout), `staging-cells` (11 swimlane blocks), `staging-words`.
- Independent per-file uniformity re-check confirmed all 27 files share identical
  `checkout@v2` + `actions-hugo@v2` + `hugo-version: '0.101.0'` before editing; deploy
  output verified live on releases-qa.aspose.com (object Last-Modified matched run times).
