### PR TITLE
Replace swimlane/s3-upload-file-action with aws s3 cp in Total stage build (Node 20)

### DIFF
--- a/.github/workflows/stage-build-total.yml
+++ b/.github/workflows/stage-build-total.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'total'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-total.xml s3://releases-qa.aspose.com/en/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/total'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-total.xml s3://releases-qa.aspose.com/de/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/total'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-total.xml s3://releases-qa.aspose.com/el/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/total'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-total.xml s3://releases-qa.aspose.com/es/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/total'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-total.xml s3://releases-qa.aspose.com/fr/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/total'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-total.xml s3://releases-qa.aspose.com/id/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/total'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-total.xml s3://releases-qa.aspose.com/ja/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/total'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-total.xml s3://releases-qa.aspose.com/pt/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/total'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-total.xml s3://releases-qa.aspose.com/ru/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/total'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-total.xml s3://releases-qa.aspose.com/tr/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/total'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-total.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-total.xml s3://releases-qa.aspose.com/zh/sitemap-total.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate


### PR DESCRIPTION
## What
Replaces the 11 `swimlane/s3-upload-file-action@main` sitemap uploads in
stage-build-total.yml with `aws s3 cp ... --content-type application/xml --acl public-read`.

## Why
swimlane runs on Node 20 (forced to Node 24 on 2026-06-16, removed 2026-09-16) and has no
Node 24-compatible release. The AWS CLI v2 is pre-installed on the ubuntu-latest runner, so
`aws s3 cp` is a drop-in with no new dependency. Uses the same ACCESS_KEY / SECRET_ACCESS
secrets already in the workflow.

## Scope
- Only the 11 swimlane steps changed. zdurham (sitemap index), jakejarvis (folder syncs),
  and chetan (CloudFront) Docker actions are untouched.

## Verification
- actionlint clean.
- workflow_dispatch staging-total: green (2m15s), zero warnings/annotations (swimlane Node 20
  + all set-output warnings gone).
- Live on releases-qa.aspose.com: /en,/de,/ja,/zh sitemap-total.xml all return 200,
  content-type application/xml, fresh Last-Modified — confirms --acl public-read kept them public.
