### PR TITLE
Replace swimlane/s3-upload-file-action with aws s3 cp across 27 stage build workflows (Node 20)

### DIFF
--- a/.github/workflows/stage-build-3d.yml
+++ b/.github/workflows/stage-build-3d.yml
@@ -131,14 +131,11 @@ jobs:
         DEST_DIR: '3d'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-3d.xml s3://releases-qa.aspose.com/en/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -153,14 +150,11 @@ jobs:
         DEST_DIR: 'de/3d'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-3d.xml s3://releases-qa.aspose.com/de/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -175,14 +169,11 @@ jobs:
         DEST_DIR: 'el/3d'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-3d.xml s3://releases-qa.aspose.com/el/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -197,14 +188,11 @@ jobs:
         DEST_DIR: 'es/3d'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-3d.xml s3://releases-qa.aspose.com/es/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -219,14 +207,11 @@ jobs:
         DEST_DIR: 'fr/3d'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-3d.xml s3://releases-qa.aspose.com/fr/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -241,14 +226,11 @@ jobs:
         DEST_DIR: 'id/3d'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-3d.xml s3://releases-qa.aspose.com/id/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -263,14 +245,11 @@ jobs:
         DEST_DIR: 'ja/3d'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-3d.xml s3://releases-qa.aspose.com/ja/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -285,14 +264,11 @@ jobs:
         DEST_DIR: 'pt/3d'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-3d.xml s3://releases-qa.aspose.com/pt/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -307,14 +283,11 @@ jobs:
         DEST_DIR: 'ru/3d'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-3d.xml s3://releases-qa.aspose.com/ru/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -329,14 +302,11 @@ jobs:
         DEST_DIR: 'tr/3d'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-3d.xml s3://releases-qa.aspose.com/tr/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -351,14 +321,11 @@ jobs:
         DEST_DIR: 'zh/3d'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-3d.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-3d.xml s3://releases-qa.aspose.com/zh/sitemap-3d.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-barcode.yml
+++ b/.github/workflows/stage-build-barcode.yml
@@ -131,14 +131,11 @@ jobs:
         DEST_DIR: 'barcode'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-barcode.xml s3://releases-qa.aspose.com/en/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -153,14 +150,11 @@ jobs:
         DEST_DIR: 'de/barcode'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-barcode.xml s3://releases-qa.aspose.com/de/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -175,14 +169,11 @@ jobs:
         DEST_DIR: 'el/barcode'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-barcode.xml s3://releases-qa.aspose.com/el/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -197,14 +188,11 @@ jobs:
         DEST_DIR: 'es/barcode'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-barcode.xml s3://releases-qa.aspose.com/es/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -219,14 +207,11 @@ jobs:
         DEST_DIR: 'fr/barcode'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-barcode.xml s3://releases-qa.aspose.com/fr/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -241,14 +226,11 @@ jobs:
         DEST_DIR: 'id/barcode'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-barcode.xml s3://releases-qa.aspose.com/id/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -263,14 +245,11 @@ jobs:
         DEST_DIR: 'ja/barcode'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-barcode.xml s3://releases-qa.aspose.com/ja/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -285,14 +264,11 @@ jobs:
         DEST_DIR: 'pt/barcode'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-barcode.xml s3://releases-qa.aspose.com/pt/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -307,14 +283,11 @@ jobs:
         DEST_DIR: 'ru/barcode'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-barcode.xml s3://releases-qa.aspose.com/ru/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -329,14 +302,11 @@ jobs:
         DEST_DIR: 'tr/barcode'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-barcode.xml s3://releases-qa.aspose.com/tr/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -351,14 +321,11 @@ jobs:
         DEST_DIR: 'zh/barcode'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-barcode.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-barcode.xml s3://releases-qa.aspose.com/zh/sitemap-barcode.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
 
     # Invalidate Cloudfront (this action)

--- a/.github/workflows/stage-build-cad.yml
+++ b/.github/workflows/stage-build-cad.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'cad'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-cad.xml s3://releases-qa.aspose.com/en/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/cad'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-cad.xml s3://releases-qa.aspose.com/de/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/cad'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-cad.xml s3://releases-qa.aspose.com/el/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/cad'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-cad.xml s3://releases-qa.aspose.com/es/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/cad'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-cad.xml s3://releases-qa.aspose.com/fr/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/cad'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-cad.xml s3://releases-qa.aspose.com/id/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/cad'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-cad.xml s3://releases-qa.aspose.com/ja/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/cad'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-cad.xml s3://releases-qa.aspose.com/pt/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/cad'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-cad.xml s3://releases-qa.aspose.com/ru/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/cad'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-cad.xml s3://releases-qa.aspose.com/tr/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/cad'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-cad.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-cad.xml s3://releases-qa.aspose.com/zh/sitemap-cad.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-cells.yml
+++ b/.github/workflows/stage-build-cells.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'cells'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-cells.xml s3://releases-qa.aspose.com/en/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/cells'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-cells.xml s3://releases-qa.aspose.com/de/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/cells'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-cells.xml s3://releases-qa.aspose.com/el/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/cells'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-cells.xml s3://releases-qa.aspose.com/es/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/cells'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-cells.xml s3://releases-qa.aspose.com/fr/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/cells'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-cells.xml s3://releases-qa.aspose.com/id/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/cells'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-cells.xml s3://releases-qa.aspose.com/ja/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/cells'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-cells.xml s3://releases-qa.aspose.com/pt/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/cells'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-cells.xml s3://releases-qa.aspose.com/ru/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/cells'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-cells.xml s3://releases-qa.aspose.com/tr/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/cells'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-cells.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-cells.xml s3://releases-qa.aspose.com/zh/sitemap-cells.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-corporate.yml
+++ b/.github/workflows/stage-build-corporate.yml
@@ -106,14 +106,11 @@ jobs:
         DEST_DIR: 'corporate'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-corporate.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-corporate.xml s3://releases-qa.aspose.com/en/sitemap-corporate.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-diagram.yml
+++ b/.github/workflows/stage-build-diagram.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'diagram'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-diagram.xml s3://releases-qa.aspose.com/en/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/diagram'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-diagram.xml s3://releases-qa.aspose.com/de/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/diagram'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-diagram.xml s3://releases-qa.aspose.com/el/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/diagram'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-diagram.xml s3://releases-qa.aspose.com/es/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/diagram'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-diagram.xml s3://releases-qa.aspose.com/fr/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/diagram'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-diagram.xml s3://releases-qa.aspose.com/id/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/diagram'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-diagram.xml s3://releases-qa.aspose.com/ja/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/diagram'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-diagram.xml s3://releases-qa.aspose.com/pt/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/diagram'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-diagram.xml s3://releases-qa.aspose.com/ru/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/diagram'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-diagram.xml s3://releases-qa.aspose.com/tr/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/diagram'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-diagram.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-diagram.xml s3://releases-qa.aspose.com/zh/sitemap-diagram.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-drawing.yml
+++ b/.github/workflows/stage-build-drawing.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'drawing'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-drawing.xml s3://releases-qa.aspose.com/en/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/drawing'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-drawing.xml s3://releases-qa.aspose.com/de/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/drawing'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-drawing.xml s3://releases-qa.aspose.com/el/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/drawing'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-drawing.xml s3://releases-qa.aspose.com/es/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/drawing'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-drawing.xml s3://releases-qa.aspose.com/fr/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/drawing'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-drawing.xml s3://releases-qa.aspose.com/id/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/drawing'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-drawing.xml s3://releases-qa.aspose.com/ja/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/drawing'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-drawing.xml s3://releases-qa.aspose.com/pt/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/drawing'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-drawing.xml s3://releases-qa.aspose.com/ru/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/drawing'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-drawing.xml s3://releases-qa.aspose.com/tr/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/drawing'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-drawing.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-drawing.xml s3://releases-qa.aspose.com/zh/sitemap-drawing.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
 
     # Invalidate Cloudfront (this action)

--- a/.github/workflows/stage-build-email.yml
+++ b/.github/workflows/stage-build-email.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'email'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-email.xml s3://releases-qa.aspose.com/en/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/email'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-email.xml s3://releases-qa.aspose.com/de/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/email'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-email.xml s3://releases-qa.aspose.com/el/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/email'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-email.xml s3://releases-qa.aspose.com/es/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/email'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-email.xml s3://releases-qa.aspose.com/fr/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/email'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-email.xml s3://releases-qa.aspose.com/id/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/email'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-email.xml s3://releases-qa.aspose.com/ja/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/email'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-email.xml s3://releases-qa.aspose.com/pt/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/email'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-email.xml s3://releases-qa.aspose.com/ru/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/email'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-email.xml s3://releases-qa.aspose.com/tr/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/email'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-email.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-email.xml s3://releases-qa.aspose.com/zh/sitemap-email.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
 
     # Invalidate Cloudfront (this action)

--- a/.github/workflows/stage-build-finance.yml
+++ b/.github/workflows/stage-build-finance.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'finance'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-finance.xml s3://releases-qa.aspose.com/en/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/finance'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-finance.xml s3://releases-qa.aspose.com/de/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/finance'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-finance.xml s3://releases-qa.aspose.com/el/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/finance'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-finance.xml s3://releases-qa.aspose.com/es/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/finance'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-finance.xml s3://releases-qa.aspose.com/fr/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/finance'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-finance.xml s3://releases-qa.aspose.com/id/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/finance'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-finance.xml s3://releases-qa.aspose.com/ja/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/finance'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-finance.xml s3://releases-qa.aspose.com/pt/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/finance'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-finance.xml s3://releases-qa.aspose.com/ru/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/finance'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-finance.xml s3://releases-qa.aspose.com/tr/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/finance'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-finance.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-finance.xml s3://releases-qa.aspose.com/zh/sitemap-finance.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-font.yml
+++ b/.github/workflows/stage-build-font.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'font'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-font.xml s3://releases-qa.aspose.com/en/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/font'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-font.xml s3://releases-qa.aspose.com/de/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/font'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-font.xml s3://releases-qa.aspose.com/el/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/font'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-font.xml s3://releases-qa.aspose.com/es/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/font'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-font.xml s3://releases-qa.aspose.com/fr/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/font'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-font.xml s3://releases-qa.aspose.com/id/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/font'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-font.xml s3://releases-qa.aspose.com/ja/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/font'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-font.xml s3://releases-qa.aspose.com/pt/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/font'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-font.xml s3://releases-qa.aspose.com/ru/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/font'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-font.xml s3://releases-qa.aspose.com/tr/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/font'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-font.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-font.xml s3://releases-qa.aspose.com/zh/sitemap-font.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-gis.yml
+++ b/.github/workflows/stage-build-gis.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'gis'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-gis.xml s3://releases-qa.aspose.com/en/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/gis'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-gis.xml s3://releases-qa.aspose.com/de/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/gis'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-gis.xml s3://releases-qa.aspose.com/el/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/gis'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-gis.xml s3://releases-qa.aspose.com/es/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/gis'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-gis.xml s3://releases-qa.aspose.com/fr/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/gis'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-gis.xml s3://releases-qa.aspose.com/id/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/gis'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-gis.xml s3://releases-qa.aspose.com/ja/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/gis'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-gis.xml s3://releases-qa.aspose.com/pt/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/gis'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-gis.xml s3://releases-qa.aspose.com/ru/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/gis'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-gis.xml s3://releases-qa.aspose.com/tr/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/gis'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-gis.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-gis.xml s3://releases-qa.aspose.com/zh/sitemap-gis.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-html.yml
+++ b/.github/workflows/stage-build-html.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'html'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-html.xml s3://releases-qa.aspose.com/en/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/html'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-html.xml s3://releases-qa.aspose.com/de/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/html'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-html.xml s3://releases-qa.aspose.com/el/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/html'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-html.xml s3://releases-qa.aspose.com/es/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/html'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-html.xml s3://releases-qa.aspose.com/fr/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/html'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-html.xml s3://releases-qa.aspose.com/id/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/html'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-html.xml s3://releases-qa.aspose.com/ja/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/html'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-html.xml s3://releases-qa.aspose.com/pt/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/html'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-html.xml s3://releases-qa.aspose.com/ru/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/html'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-html.xml s3://releases-qa.aspose.com/tr/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/html'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-html.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-html.xml s3://releases-qa.aspose.com/zh/sitemap-html.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-imaging.yml
+++ b/.github/workflows/stage-build-imaging.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'imaging'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-imaging.xml s3://releases-qa.aspose.com/en/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/imaging'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-imaging.xml s3://releases-qa.aspose.com/de/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/imaging'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-imaging.xml s3://releases-qa.aspose.com/el/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/imaging'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-imaging.xml s3://releases-qa.aspose.com/es/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/imaging'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-imaging.xml s3://releases-qa.aspose.com/fr/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/imaging'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-imaging.xml s3://releases-qa.aspose.com/id/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/imaging'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-imaging.xml s3://releases-qa.aspose.com/ja/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/imaging'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-imaging.xml s3://releases-qa.aspose.com/pt/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/imaging'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-imaging.xml s3://releases-qa.aspose.com/ru/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/imaging'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-imaging.xml s3://releases-qa.aspose.com/tr/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/imaging'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-imaging.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-imaging.xml s3://releases-qa.aspose.com/zh/sitemap-imaging.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-llm.yml
+++ b/.github/workflows/stage-build-llm.yml
@@ -79,14 +79,11 @@ jobs:
         DEST_DIR: 'llm'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-llm.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-llm.xml s3://releases-qa.aspose.com/en/sitemap-llm.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
 
     # Invalidate Cloudfront (this action)

--- a/.github/workflows/stage-build-note.yml
+++ b/.github/workflows/stage-build-note.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'note'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-note.xml s3://releases-qa.aspose.com/en/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/note'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-note.xml s3://releases-qa.aspose.com/de/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/note'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-note.xml s3://releases-qa.aspose.com/el/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/note'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-note.xml s3://releases-qa.aspose.com/es/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/note'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-note.xml s3://releases-qa.aspose.com/fr/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/note'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-note.xml s3://releases-qa.aspose.com/id/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/note'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-note.xml s3://releases-qa.aspose.com/ja/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/note'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-note.xml s3://releases-qa.aspose.com/pt/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/note'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-note.xml s3://releases-qa.aspose.com/ru/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/note'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-note.xml s3://releases-qa.aspose.com/tr/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/note'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-note.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-note.xml s3://releases-qa.aspose.com/zh/sitemap-note.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-ocr.yml
+++ b/.github/workflows/stage-build-ocr.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'ocr'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-ocr.xml s3://releases-qa.aspose.com/en/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/ocr'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-ocr.xml s3://releases-qa.aspose.com/de/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/ocr'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-ocr.xml s3://releases-qa.aspose.com/el/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/ocr'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-ocr.xml s3://releases-qa.aspose.com/es/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/ocr'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-ocr.xml s3://releases-qa.aspose.com/fr/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/ocr'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-ocr.xml s3://releases-qa.aspose.com/id/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/ocr'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-ocr.xml s3://releases-qa.aspose.com/ja/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/ocr'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-ocr.xml s3://releases-qa.aspose.com/pt/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/ocr'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-ocr.xml s3://releases-qa.aspose.com/ru/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/ocr'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-ocr.xml s3://releases-qa.aspose.com/tr/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/ocr'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-ocr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-ocr.xml s3://releases-qa.aspose.com/zh/sitemap-ocr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-omr.yml
+++ b/.github/workflows/stage-build-omr.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'omr'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-omr.xml s3://releases-qa.aspose.com/en/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/omr'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-omr.xml s3://releases-qa.aspose.com/de/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/omr'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-omr.xml s3://releases-qa.aspose.com/el/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/omr'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-omr.xml s3://releases-qa.aspose.com/es/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/omr'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-omr.xml s3://releases-qa.aspose.com/fr/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/omr'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-omr.xml s3://releases-qa.aspose.com/id/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/omr'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-omr.xml s3://releases-qa.aspose.com/ja/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/omr'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-omr.xml s3://releases-qa.aspose.com/pt/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/omr'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-omr.xml s3://releases-qa.aspose.com/ru/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/omr'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-omr.xml s3://releases-qa.aspose.com/tr/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/omr'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-omr.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-omr.xml s3://releases-qa.aspose.com/zh/sitemap-omr.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-page.yml
+++ b/.github/workflows/stage-build-page.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'page'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-page.xml s3://releases-qa.aspose.com/en/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/page'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-page.xml s3://releases-qa.aspose.com/de/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/page'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-page.xml s3://releases-qa.aspose.com/el/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/page'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-page.xml s3://releases-qa.aspose.com/es/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/page'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-page.xml s3://releases-qa.aspose.com/fr/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/page'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-page.xml s3://releases-qa.aspose.com/id/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/page'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-page.xml s3://releases-qa.aspose.com/ja/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/page'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-page.xml s3://releases-qa.aspose.com/pt/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/page'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-page.xml s3://releases-qa.aspose.com/ru/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/page'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-page.xml s3://releases-qa.aspose.com/tr/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/page'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-page.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-page.xml s3://releases-qa.aspose.com/zh/sitemap-page.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-pdf.yml
+++ b/.github/workflows/stage-build-pdf.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'pdf'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-pdf.xml s3://releases-qa.aspose.com/en/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/pdf'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-pdf.xml s3://releases-qa.aspose.com/de/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/pdf'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-pdf.xml s3://releases-qa.aspose.com/el/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/pdf'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-pdf.xml s3://releases-qa.aspose.com/es/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/pdf'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-pdf.xml s3://releases-qa.aspose.com/fr/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/pdf'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-pdf.xml s3://releases-qa.aspose.com/id/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/pdf'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-pdf.xml s3://releases-qa.aspose.com/ja/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/pdf'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-pdf.xml s3://releases-qa.aspose.com/pt/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/pdf'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-pdf.xml s3://releases-qa.aspose.com/ru/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/pdf'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-pdf.xml s3://releases-qa.aspose.com/tr/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/pdf'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-pdf.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-pdf.xml s3://releases-qa.aspose.com/zh/sitemap-pdf.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-psd.yml
+++ b/.github/workflows/stage-build-psd.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'psd'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-psd.xml s3://releases-qa.aspose.com/en/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/psd'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-psd.xml s3://releases-qa.aspose.com/de/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/psd'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-psd.xml s3://releases-qa.aspose.com/el/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/psd'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-psd.xml s3://releases-qa.aspose.com/es/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/psd'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-psd.xml s3://releases-qa.aspose.com/fr/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/psd'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-psd.xml s3://releases-qa.aspose.com/id/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/psd'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-psd.xml s3://releases-qa.aspose.com/ja/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/psd'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-psd.xml s3://releases-qa.aspose.com/pt/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/psd'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-psd.xml s3://releases-qa.aspose.com/ru/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/psd'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-psd.xml s3://releases-qa.aspose.com/tr/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/psd'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-psd.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-psd.xml s3://releases-qa.aspose.com/zh/sitemap-psd.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-pub.yml
+++ b/.github/workflows/stage-build-pub.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'pub'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-pub.xml s3://releases-qa.aspose.com/en/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/pub'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-pub.xml s3://releases-qa.aspose.com/de/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/pub'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-pub.xml s3://releases-qa.aspose.com/el/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/pub'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-pub.xml s3://releases-qa.aspose.com/es/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/pub'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-pub.xml s3://releases-qa.aspose.com/fr/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/pub'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-pub.xml s3://releases-qa.aspose.com/id/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/pub'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-pub.xml s3://releases-qa.aspose.com/ja/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/pub'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-pub.xml s3://releases-qa.aspose.com/pt/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/pub'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-pub.xml s3://releases-qa.aspose.com/ru/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/pub'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-pub.xml s3://releases-qa.aspose.com/tr/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/pub'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-pub.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-pub.xml s3://releases-qa.aspose.com/zh/sitemap-pub.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-slides.yml
+++ b/.github/workflows/stage-build-slides.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'slides'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-slides.xml s3://releases-qa.aspose.com/en/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/slides'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-slides.xml s3://releases-qa.aspose.com/de/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/slides'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-slides.xml s3://releases-qa.aspose.com/el/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/slides'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-slides.xml s3://releases-qa.aspose.com/es/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/slides'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-slides.xml s3://releases-qa.aspose.com/fr/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/slides'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-slides.xml s3://releases-qa.aspose.com/id/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/slides'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-slides.xml s3://releases-qa.aspose.com/ja/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/slides'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-slides.xml s3://releases-qa.aspose.com/pt/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/slides'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-slides.xml s3://releases-qa.aspose.com/ru/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/slides'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-slides.xml s3://releases-qa.aspose.com/tr/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/slides'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-slides.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-slides.xml s3://releases-qa.aspose.com/zh/sitemap-slides.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-svg.yml
+++ b/.github/workflows/stage-build-svg.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'svg'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-svg.xml s3://releases-qa.aspose.com/en/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/svg'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-svg.xml s3://releases-qa.aspose.com/de/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/svg'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-svg.xml s3://releases-qa.aspose.com/el/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/svg'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-svg.xml s3://releases-qa.aspose.com/es/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/svg'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-svg.xml s3://releases-qa.aspose.com/fr/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/svg'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-svg.xml s3://releases-qa.aspose.com/id/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/svg'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-svg.xml s3://releases-qa.aspose.com/ja/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/svg'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-svg.xml s3://releases-qa.aspose.com/pt/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/svg'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-svg.xml s3://releases-qa.aspose.com/ru/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/svg'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-svg.xml s3://releases-qa.aspose.com/tr/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/svg'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-svg.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-svg.xml s3://releases-qa.aspose.com/zh/sitemap-svg.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-tasks.yml
+++ b/.github/workflows/stage-build-tasks.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'tasks'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-tasks.xml s3://releases-qa.aspose.com/en/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/tasks'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-tasks.xml s3://releases-qa.aspose.com/de/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/tasks'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-tasks.xml s3://releases-qa.aspose.com/el/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/tasks'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-tasks.xml s3://releases-qa.aspose.com/es/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/tasks'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-tasks.xml s3://releases-qa.aspose.com/fr/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/tasks'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-tasks.xml s3://releases-qa.aspose.com/id/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/tasks'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-tasks.xml s3://releases-qa.aspose.com/ja/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/tasks'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-tasks.xml s3://releases-qa.aspose.com/pt/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/tasks'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-tasks.xml s3://releases-qa.aspose.com/ru/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/tasks'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-tasks.xml s3://releases-qa.aspose.com/tr/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/tasks'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-tasks.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-tasks.xml s3://releases-qa.aspose.com/zh/sitemap-tasks.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-tex.yml
+++ b/.github/workflows/stage-build-tex.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'tex'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-tex.xml s3://releases-qa.aspose.com/en/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/tex'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-tex.xml s3://releases-qa.aspose.com/de/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/tex'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-tex.xml s3://releases-qa.aspose.com/el/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/tex'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-tex.xml s3://releases-qa.aspose.com/es/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/tex'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-tex.xml s3://releases-qa.aspose.com/fr/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/tex'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-tex.xml s3://releases-qa.aspose.com/id/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/tex'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-tex.xml s3://releases-qa.aspose.com/ja/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/tex'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-tex.xml s3://releases-qa.aspose.com/pt/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/tex'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-tex.xml s3://releases-qa.aspose.com/ru/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/tex'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-tex.xml s3://releases-qa.aspose.com/tr/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/tex'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-tex.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-tex.xml s3://releases-qa.aspose.com/zh/sitemap-tex.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-words.yml
+++ b/.github/workflows/stage-build-words.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'words'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-words.xml s3://releases-qa.aspose.com/en/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/words'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-words.xml s3://releases-qa.aspose.com/de/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/words'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-words.xml s3://releases-qa.aspose.com/el/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/words'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-words.xml s3://releases-qa.aspose.com/es/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/words'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-words.xml s3://releases-qa.aspose.com/fr/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/words'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-words.xml s3://releases-qa.aspose.com/id/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/words'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-words.xml s3://releases-qa.aspose.com/ja/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/words'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-words.xml s3://releases-qa.aspose.com/pt/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/words'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-words.xml s3://releases-qa.aspose.com/ru/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/words'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-words.xml s3://releases-qa.aspose.com/tr/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/words'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-words.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-words.xml s3://releases-qa.aspose.com/zh/sitemap-words.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate

--- a/.github/workflows/stage-build-zip.yml
+++ b/.github/workflows/stage-build-zip.yml
@@ -128,14 +128,11 @@ jobs:
         DEST_DIR: 'zip'
 
     - name: Upload en sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/en/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'en/'
+      run: aws s3 cp public/en/sitemap-zip.xml s3://releases-qa.aspose.com/en/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload de folder
       uses: jakejarvis/s3-sync-action@master
@@ -150,14 +147,11 @@ jobs:
         DEST_DIR: 'de/zip'
 
     - name: Upload de sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/de/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'de/'
+      run: aws s3 cp public/de/sitemap-zip.xml s3://releases-qa.aspose.com/de/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload el folder
       uses: jakejarvis/s3-sync-action@master
@@ -172,14 +166,11 @@ jobs:
         DEST_DIR: 'el/zip'
 
     - name: Upload el sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/el/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'el/'
+      run: aws s3 cp public/el/sitemap-zip.xml s3://releases-qa.aspose.com/el/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload es folder
       uses: jakejarvis/s3-sync-action@master
@@ -194,14 +185,11 @@ jobs:
         DEST_DIR: 'es/zip'
 
     - name: Upload es sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/es/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'es/'
+      run: aws s3 cp public/es/sitemap-zip.xml s3://releases-qa.aspose.com/es/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload fr folder
       uses: jakejarvis/s3-sync-action@master
@@ -216,14 +204,11 @@ jobs:
         DEST_DIR: 'fr/zip'
 
     - name: Upload fr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/fr/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'fr/'
+      run: aws s3 cp public/fr/sitemap-zip.xml s3://releases-qa.aspose.com/fr/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload id folder
       uses: jakejarvis/s3-sync-action@master
@@ -238,14 +223,11 @@ jobs:
         DEST_DIR: 'id/zip'
 
     - name: Upload id sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/id/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'id/'
+      run: aws s3 cp public/id/sitemap-zip.xml s3://releases-qa.aspose.com/id/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ja folder
       uses: jakejarvis/s3-sync-action@master
@@ -260,14 +242,11 @@ jobs:
         DEST_DIR: 'ja/zip'
 
     - name: Upload ja sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ja/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ja/'
+      run: aws s3 cp public/ja/sitemap-zip.xml s3://releases-qa.aspose.com/ja/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload pt folder
       uses: jakejarvis/s3-sync-action@master
@@ -282,14 +261,11 @@ jobs:
         DEST_DIR: 'pt/zip'
 
     - name: Upload pt sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/pt/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'pt/'
+      run: aws s3 cp public/pt/sitemap-zip.xml s3://releases-qa.aspose.com/pt/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload ru folder
       uses: jakejarvis/s3-sync-action@master
@@ -304,14 +280,11 @@ jobs:
         DEST_DIR: 'ru/zip'
 
     - name: Upload ru sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/ru/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'ru/'
+      run: aws s3 cp public/ru/sitemap-zip.xml s3://releases-qa.aspose.com/ru/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload tr folder
       uses: jakejarvis/s3-sync-action@master
@@ -326,14 +299,11 @@ jobs:
         DEST_DIR: 'tr/zip'
 
     - name: Upload tr sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/tr/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'tr/'
+      run: aws s3 cp public/tr/sitemap-zip.xml s3://releases-qa.aspose.com/tr/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     - name: Upload zh folder
       uses: jakejarvis/s3-sync-action@master
@@ -348,14 +318,11 @@ jobs:
         DEST_DIR: 'zh/zip'
 
     - name: Upload zh sitemap
-      uses: swimlane/s3-upload-file-action@main
-      with:
-        aws_access_key_id: ${{ secrets.ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.SECRET_ACCESS}}
-        aws_bucket: 'releases-qa.aspose.com'
-        file_path: 'public/zh/sitemap-zip.xml'
-        file_mime_type: 'application/xml'
-        dest_dir: 'zh/'
+      run: aws s3 cp public/zh/sitemap-zip.xml s3://releases-qa.aspose.com/zh/sitemap-zip.xml --content-type application/xml --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+        AWS_DEFAULT_REGION: us-west-2
 
     # Invalidate Cloudfront (this action)
     - name: invalidate


### PR DESCRIPTION
## What
Replaces swimlane/s3-upload-file-action@main with `aws s3 cp ... --content-type application/xml
--acl public-read` across the remaining 27 stage-build-*.yml workflows (277 sitemap uploads).
Completes the swimlane removal started for total in #881.

## Why
swimlane runs on Node 20 (forced to Node 24 on 2026-06-16, no compatible release). AWS CLI v2
is pre-installed on the runner; reuses existing ACCESS_KEY / SECRET_ACCESS secrets.

## Scope
- Only swimlane steps changed. zdurham / jakejarvis / chetan Docker actions untouched.
- corporate and llm have 1 block each; the other 25 have 11.

## Verification
- actionlint clean across all 28 stage-build workflows; 0 swimlane remaining.
- workflow_dispatch green: staging-llm (1-block) and staging-pdf (11-block), zero warnings.
- Live on releases-qa.aspose.com: llm + 5 pdf language sitemaps return 200,
  content-type application/xml, fresh Last-Modified (confirms --acl public-read).
