### PR TITLE
Stage stragglers: Node 24 action upgrades, macos-15-intel pin, CloudFront invalidation fix

### DIFF
--- a/.github/workflows/releases-aspose-com-stage.yml
+++ b/.github/workflows/releases-aspose-com-stage.yml
@@ -33,20 +33,20 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: macos-15-intel
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
             submodules: true  # Fetch Hugo themes
             fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       # Step 2 - Sets up the latest version of Hugo
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
             hugo-version: '0.101.0'
 

--- a/.github/workflows/releases-aspose-com-stage.yml
+++ b/.github/workflows/releases-aspose-com-stage.yml
@@ -88,22 +88,38 @@ jobs:
              echo $p | sed -e 's/\/content//' | sed -e 's/new-releases/*/' | sed -e 's/$/\//' | sed -e 's/\/\//\//' | sed -e 's/*\//*/'
           done | sort | uniq | tr '\n' ' ' > .updated_files
 
-      # Invalidate Cloudfront (this action)
+      # Invalidate Cloudfront (AWS CLI; Docker actions are not supported on macOS runners)
       - name: invalidate
-        uses: chetan/invalidate-cloudfront-action@master
+        shell: bash
+        run: |
+          if [ ! -f .updated_files ]; then
+            echo "PATHS file not found. nothing to do. exiting"
+            exit 0
+          fi
+
+          PATHS=$(cat .updated_files)
+          if [ -z "$PATHS" ]; then
+            echo "PATHS is empty. nothing to do. exiting"
+            exit 0
+          fi
+
+          IFS=', ' read -r -a PATHS_ARR <<< "$PATHS"
+          if [ "${#PATHS_ARR[@]}" -gt 0 ]; then
+            aws cloudfront create-invalidation \
+              --distribution-id "${{ secrets.AWS_DISTRIBUTION }}" \
+              --paths "${PATHS_ARR[@]}"
+          fi
         env:
-          DISTRIBUTION: ${{ secrets.AWS_DISTRIBUTION }}
-          PATHS_FROM: .updated_files
-          AWS_REGION: 'us-west-2'
           AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+          AWS_REGION: us-west-2
+          AWS_DEFAULT_REGION: us-west-2
       # Invalidate Cloudfront Home Page
       - name: invalidate
         continue-on-error: true
-        uses: chetan/invalidate-cloudfront-action@master
+        run: aws cloudfront create-invalidation --distribution-id "${{ secrets.AWS_DISTRIBUTION }}" --paths "/*" "/index.html" "/index.json"
         env:
-          DISTRIBUTION: ${{ secrets.AWS_DISTRIBUTION }}
-          PATHS: /* /index.html /index.json
-          AWS_REGION: 'us-west-2'
           AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+          AWS_REGION: us-west-2
+          AWS_DEFAULT_REGION: us-west-2

--- a/.github/workflows/repopost.yml
+++ b/.github/workflows/repopost.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: repo
 
       - name: Set up JDK 1.11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Build
         env:

--- a/.github/workflows/staging-complete.yml
+++ b/.github/workflows/staging-complete.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Dispatch Events
-      uses: peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@v4
       with:
           token:  ${{ secrets.ASPOSE_REPO_CI }}
           repository: Aspose/releases.aspose.com


### PR DESCRIPTION
Completes the Node 20 / runner-image deprecation remediation for the STAGE side (follows #878, #880, #881, #883).

## Changes

**releases-aspose-com-stage.yml** (full-site stage build)
- `runs-on: macos-latest` → `macos-15-intel` (pins ahead of the June 15, 2026 macOS 26 migration; Intel x64, 14 GB — matches the architecture already pinned in the prod counterpart)
- `actions/checkout@v2` → `@v5`
- `peaceiris/actions-hugo@v2` → `@v3`
- Both `chetan/invalidate-cloudfront-action@master` steps replaced with direct `aws cloudfront create-invalidation` run steps. Docker container actions cannot run on macOS runners ("Container action is only supported on Linux"), so these steps have failed on every prior run of this workflow — deploys succeeded but CloudFront invalidation silently never happened, and every run ended red. Replacement preserves the original semantics 1:1 (same paths, same secrets, step 1 failure-fatal / step 2 continue-on-error), with quoted-array path handling so wildcard paths like `/*` reach AWS unexpanded.

**repopost.yml**
- `actions/checkout@v3` → `@v5`
- `actions/setup-java@v5`, `distribution: adopt` → `temurin` (same OpenJDK 11 lineage; AdoptOpenJDK is frozen post-rename)

**staging-complete.yml**
- `peter-evans/repository-dispatch@v1` → `@v4`

## Testing (all pre-merge, dispatched from this branch)

- **repopost**: green (2m31s) — temurin-11 resolved, `mvn package` + `exec:java` succeeded against the QA bucket with `repoBranch=stage`; idempotent re-run of total 26.4 pushed the expected empty commit (91a7e7ea25), no content change, no builds triggered
- **StagingComplete**: green (10s) — repository-dispatch@v4 sends successfully
- **Full-site build**: green in 1h04m on macos-15-intel — first fully green run in this workflow's history. Hugo 0.101.0 darwin/amd64, deploy verified live (sitemap-tags.xml Last-Modified matches run time), CloudFront invalidation created successfully (status InProgress, 3 paths)
- actionlint clean on all three files; changes independently peer-reviewed (2026-06-11, both rounds: batch + invalidation fix)

## Deferred (production track)

- `releases-aspose-com-prod.yml` has the identical macOS + Docker-action invalidation defect — will be fixed with the prod-track remediation on `main`
- `prod-build-*.yml` (×28), `repopost.yml` (main copy), `prod-complete.yml` — same upgrades, branches off `main`

After merge, the stage side is 100% remediated: zero deprecated-action warnings across all stage workflows, ahead of the June 15/16 deadlines.
