### PR TITLE
Prod full-site workflow: checkout@v5, actions-hugo@v3, AWS CLI CloudFront invalidation

### DIFF
--- a/.github/workflows/releases-aspose-com-prod.yml
+++ b/.github/workflows/releases-aspose-com-prod.yml
@@ -48,14 +48,14 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
             submodules: true  # Fetch Hugo themes
             fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       # Step 2 - Sets up the latest version of Hugo
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
             hugo-version: '0.101.0'
 
@@ -84,13 +84,12 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
 
-      # Invalidate Cloudfront Home Page
+      # Invalidate Cloudfront Home Page (AWS CLI; Docker actions are not supported on macOS runners)
       - name: invalidate
         continue-on-error: true
-        uses: chetan/invalidate-cloudfront-action@master
+        run: aws cloudfront create-invalidation --distribution-id "${{ secrets.AWS_DISTRIBUTION_PROD }}" --paths "/" "/*"
         env:
-          DISTRIBUTION: ${{ secrets.AWS_DISTRIBUTION_PROD }}
-          PATHS: / /**
-          AWS_REGION: 'us-west-2'
           AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS }}
+          AWS_REGION: us-west-2
+          AWS_DEFAULT_REGION: us-west-2

--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,7 @@ MigrationBackup/
 
 # JetBrains folders
 .idea
+
+# AI assistant working folders
+.claude/
+.codex/


### PR DESCRIPTION
## Summary

Remediates the GitHub Actions Node 16/20 deprecations and a long-standing CloudFront
invalidation defect in the production full-site workflow
(`.github/workflows/releases-aspose-com-prod.yml`). Production counterpart of the
stage-side fixes merged via PR #886. Also extends `.gitignore` with local tool
working folders.

Deadlines driving this: GitHub forces Node 20 actions onto Node 24 on **2026-06-16**
(removal 2026-09-16).

## Changes

### 1. `actions/checkout` v3 → v5
Node 16 → Node 24 runtime. Inputs we use (`submodules: true`, `fetch-depth: 0`)
are unchanged in v5.

### 2. `peaceiris/actions-hugo` v2 → v3
Node 16 → Node 24 runtime. `hugo-version` stays pinned at `0.101.0`, so the Hugo
binary and built output are identical.

### 3. CloudFront invalidation: `chetan/invalidate-cloudfront-action@master` → direct AWS CLI
**This step has silently failed on every macOS run in this workflow's history.**
`chetan/invalidate-cloudfront-action` is a Docker container action, and GitHub
Actions cannot run Docker actions on macOS runners ("Container action is only
supported on Linux"). Deploys still completed, but the CDN cache was never
invalidated. Replaced with a direct `aws cloudfront create-invalidation` call
(AWS CLI is preinstalled on the runner image), mirroring the fix proven on the
stage branch (PR #886).

Details preserved / normalized:
- Secret `AWS_DISTRIBUTION_PROD`, same `ACCESS_KEY`/`SECRET_ACCESS` credentials,
  same region (`us-west-2`, now set as both `AWS_REGION` and `AWS_DEFAULT_REGION`
  so the CLI resolves a region under either variable name)
- `continue-on-error: true` kept (historical behavior)
- Paths normalized from `/ /**` to `"/" "/*"` — `/**` is invalid per the CloudFront
  API (a single `*` is allowed only as the final character) and appears nowhere
  else in our workflow estate; `/*` is the documented "everything" form used by
  all sister repos. The invalid value was never caught because the step never
  executed.

### 4. `.gitignore`: ignore `.claude/` and `.codex/`
Prevents accidental commits of local tool working folders (matches the equivalent
entry already on the `stage` branch).

## Not in scope (deliberate)
- No targeted `.updated_files` invalidation step added (prod has never had one;
  adding it would be a behavior expansion)
- Runner unchanged — `macos-15-intel` pin was already in place
- 29× `prod-build-*.yml`, `repopost.yml`, `prod-complete.yml`/`staging-complete.yml`
  follow in subsequent PRs

## Testing & verification

- `actionlint` clean on the edited workflow
- `workflow_dispatch` run **#2762** from this branch (same-content redeploy of
  `main`, deploy uses `--maxDeletes 0`): **green in 3h05m** on `macos-15-intel`
  - checkout@v5 + actions-hugo@v3 ran clean, hugo `darwin/amd64` (Intel confirmed),
    full build of ~166k pages across 11 languages
  - **First successful production CloudFront invalidation for this workflow:**
    `IDD5FKFYTNZYESWGF7KZF495KT`, status `InProgress`, 2 paths (`/*`, `/`)
  - Zero deprecation warnings/annotations
- Live-site verification post-deploy: `en`/`de` `sitemap-tags.xml` → HTTP 200,
  `application/xml`, `Last-Modified` 2026-06-12 10:05 GMT (= deploy time);
  `X-Cache: Miss from cloudfront` confirms the invalidation flushed the CDN

Note: merging this PR does not auto-trigger the workflow (the changed files do
not match its `paths:` filters).