### PR TITLE
P5+P6: Node20 deprecation fixes for repopost + prod/staging-complete

### DIFF
--- a/.github/workflows/prod-complete.yml
+++ b/.github/workflows/prod-complete.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Dispatch Events
-      uses: peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@v4
       with:
           token:  ${{ secrets.ASPOSE_REPO_CI }}
           repository: Aspose/releases.aspose.com

--- a/.github/workflows/repopost.yml
+++ b/.github/workflows/repopost.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: repo
 
       - name: Set up JDK 1.11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Build
         env:

--- a/.github/workflows/staging-complete.yml
+++ b/.github/workflows/staging-complete.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Dispatch Events
-      uses: peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@v4
       with:
           token:  ${{ secrets.ASPOSE_REPO_CI }}
           repository: Aspose/releases.aspose.com


### PR DESCRIPTION
Final production stragglers for the GitHub Actions Node20/runner deprecation
remediation on releases.aspose.com (main). 5 lines, 3 files:

- repopost.yml: actions/checkout@v3->v5, actions/setup-java@v2->v5,
  distribution adopt->temurin (java-version 11 unchanged)
- prod-complete.yml: peter-evans/repository-dispatch@v1->v4
- staging-complete.yml: peter-evans/repository-dispatch@v1->v4

Testing (all green, from branch prod-stragglers-node20):
- repopost dispatched with aspose/total/26.4/repoBranch=stage -> Temurin
  Java 11 resolved, mvn package + exec:java green; expected empty idempotent
  commit landed on stage only (65678db), zero production impact.
- ProdComplete + StagingComplete dispatched -> @v4 sends OK on Node24;
  no active listeners, nothing downstream fires.
- actionlint clean on all 3 files.

No deviations: only the planned 5 lines changed; no formatting/comment edits.