### PR TITLE
Add Aspose.LLM for .NET 26.6.0 release notes

### DIFF
--- a/content/en/llm/net/release-notes/2026/aspose-llm-for-net-26-3-0-release-notes.md
+++ b/content/en/llm/net/release-notes/2026/aspose-llm-for-net-26-3-0-release-notes.md
@@ -3,7 +3,7 @@ id: "aspose-llm-for-net-26-3-0-release-notes"
 slug: "aspose-llm-for-net-26-3-0-release-notes"
 linktitle: "Aspose.LLM for .NET 26.3.0 Release Notes"
 title: "Aspose.LLM for .NET 26.3.0 Release Notes"
-weight: 30
+weight: 40
 description: "Aspose.LLM for .NET 26.3.0 Release Notes - the latest updates and fixes."
 type: "repository"
 layout: "release"

--- a/content/en/llm/net/release-notes/2026/aspose-llm-for-net-26-4-0-release-notes.md
+++ b/content/en/llm/net/release-notes/2026/aspose-llm-for-net-26-4-0-release-notes.md
@@ -3,7 +3,7 @@ id: "aspose-llm-for-net-26-4-0-release-notes"
 slug: "aspose-llm-for-net-26-4-0-release-notes"
 linktitle: "Aspose.LLM for .NET 26.4.0 Release Notes"
 title: "Aspose.LLM for .NET 26.4.0 Release Notes"
-weight: 20
+weight: 30
 description: "Aspose.LLM for .NET 26.4.0 Release Notes - the latest updates and fixes."
 type: "repository"
 layout: "release"

--- a/content/en/llm/net/release-notes/2026/aspose-llm-for-net-26-5-0-release-notes.md
+++ b/content/en/llm/net/release-notes/2026/aspose-llm-for-net-26-5-0-release-notes.md
@@ -3,7 +3,7 @@ id: "aspose-llm-for-net-26-5-0-release-notes"
 slug: "aspose-llm-for-net-26-5-0-release-notes"
 linktitle: "Aspose.LLM for .NET 26.5.0 Release Notes"
 title: "Aspose.LLM for .NET 26.5.0 Release Notes"
-weight: 10
+weight: 20
 description: "Aspose.LLM for .NET 26.5.0 Release Notes - the latest updates and fixes."
 type: "repository"
 layout: "release"

--- a/content/en/llm/net/release-notes/2026/aspose-llm-for-net-26-6-0-release-notes.md
+++ b/content/en/llm/net/release-notes/2026/aspose-llm-for-net-26-6-0-release-notes.md
@@ -1,0 +1,30 @@
+---
+id: "aspose-llm-for-net-26-6-0-release-notes"
+slug: "aspose-llm-for-net-26-6-0-release-notes"
+linktitle: "Aspose.LLM for .NET 26.6.0 Release Notes"
+title: "Aspose.LLM for .NET 26.6.0 Release Notes"
+weight: 10
+description: "Aspose.LLM for .NET 26.6.0 Release Notes - the latest updates and fixes."
+type: "repository"
+layout: "release"
+---
+
+This release improves Aspose.LLM for .NET model support, preset coverage, and chat reliability.
+
+## Improvements
+
+- Runtime component and local model cache paths can now be configured through environment variables.
+
+Configure model and runtime cache paths using environment variables.
+```csharp
+Environment.SetEnvironmentVariable("ASPOSE_LLM_MODEL_CACHE_DIR", "/custom/model/cache");
+Environment.SetEnvironmentVariable("ASPOSE_LLM_RUNTIME_CACHE_DIR", "/custom/runtime/cache");
+```
+
+- Added JSON preset import and export functionality for reusable preset configuration.
+
+Demonstrates saving a loaded preset to JSON with compact export (excluding default values).
+```csharp
+var preset = AsposeLLMApi.LoadPresetFromJson("{\"presetType\":\"Default\"}");
+string compactJson = AsposeLLMApi.SavePresetToJson(preset, includeDefaults: false);
+```


### PR DESCRIPTION
Autonomous release notes publication for Aspose.LLM for .NET 26.6.0.