### PR TITLE
Release notes (net): HTML 26.6.0

### DIFF
--- a/content/en/html/net/release-notes/2026/aspose-html-for-net-26.6.0-release-notes.md
+++ b/content/en/html/net/release-notes/2026/aspose-html-for-net-26.6.0-release-notes.md
@@ -1,0 +1,32 @@
+---
+id: "aspose-html-for-net-26-6-release-notes"
+slug: "aspose-html-for-net-26-6-release-notes"
+linktitle: "Aspose.HTML for .NET 26.6 Release Notes"
+title: "Aspose.HTML for .NET 26.6 Release Notes"
+weight: 70
+description: "Aspose.HTML for .NET 26.6 Release Notes - the latest updates and fixes."
+type: "repository"
+layout: "release"
+hideChildren: false
+toc: false
+family_listing_page_title: "Aspose.HTML for .NET 26.6 Release Notes"
+menuItemWithNoContent: false
+---
+
+{{% alert color="primary" %}}
+This page contains release notes information for Aspose.HTML for .NET 26.6.
+{{% /alert %}}
+
+As per the regular monthly update process of all APIs being offered by Aspose, we are honored to announce the June release of Aspose.HTML for .NET.
+
+### Release Notes
+
+Aspose.HTML for .NET 26.6.0 is published as part of the June monthly release.
+
+**Package references**<br>
+Aspose.HTML for .NET 26.6.0 [NuGet](https://www.nuget.org/packages/Aspose.Html)<br>
+Aspose.HTML for Python via .NET  26.6.0 [PyPI](https://pypi.org/project/aspose-html-net/)
+
+## **Improvements and Changes**
+
+- Maintenance build for the June 26.6.0 release of Aspose.HTML for .NET.


### PR DESCRIPTION
Auto-generated release notes for HTML 26.6.0 (net).