### PR TITLE
Release notes (net): HTML 26.6.0

### DIFF
--- a/content/en/html/net/release-notes/2026/aspose-html-for-net-26.6.0-release-notes.md
+++ b/content/en/html/net/release-notes/2026/aspose-html-for-net-26.6.0-release-notes.md
@@ -21,7 +21,7 @@ As per the regular monthly update process of all APIs being offered by Aspose, w
 
 ### Release Notes
 
-Aspose.HTML for .NET 26.6.0 is published as part of the June monthly release.
+The June update for Aspose.HTML for .NET focuses on rendering consistency, advanced layout behavior, and overall stability.
 
 **Package references**<br>
 Aspose.HTML for .NET 26.6.0 [NuGet](https://www.nuget.org/packages/Aspose.Html)<br>
@@ -29,4 +29,13 @@ Aspose.HTML for Python via .NET  26.6.0 [PyPI](https://pypi.org/project/aspose-h
 
 ## **Improvements and Changes**
 
-- Maintenance build for the June 26.6.0 release of Aspose.HTML for .NET.
+| **Key** | **Summary** | **Category** |
+| ------------ | -------------------------------------------------------------------------------------- | ------------ |
+| HTMLNET-7104 | Fixed an ArgumentException caused by incompatible unit types that could occur during Flexbox layout. | Bug |
+| HTMLNET-6717 | Resolved a stack overflow exception that could arise while processing large documents. | Bug |
+| HTMLNET-6699 | Resolved a problem with emoji rendering. | Bug |
+| HTMLNET-6403 | Resolved a page-break bug that produced incorrect pagination during rendering. | Bug |
+| HTMLNET-4786 | The layout engine now computes logical size and block size to improve layout sizing. | Bug |
+| HTMLNET-3081 | Corrected cell background painting to span all rows covered by a rowspan cell. | Bug |
+| HTMLNET-6925 | The library now supports the `space-evenly` value for `align-content` and `justify-content` in Flexbox and Grid layouts. | Feature |
+| HTMLNET-5407 | The library now supports the CSS textalignlast property and lastline text justification. | Feature |

--- a/content/en/html/net/release-notes/2026/aspose-html-for-net-26.6.0-release-notes.md
+++ b/content/en/html/net/release-notes/2026/aspose-html-for-net-26.6.0-release-notes.md
@@ -1,0 +1,32 @@
+---
+id: "aspose-html-for-net-26-6-release-notes"
+slug: "aspose-html-for-net-26-6-release-notes"
+linktitle: "Aspose.HTML for .NET 26.6 Release Notes"
+title: "Aspose.HTML for .NET 26.6 Release Notes"
+weight: 70
+description: "Aspose.HTML for .NET 26.6 Release Notes - the latest updates and fixes."
+type: "repository"
+layout: "release"
+hideChildren: false
+toc: false
+family_listing_page_title: "Aspose.HTML for .NET 26.6 Release Notes"
+menuItemWithNoContent: false
+---
+
+{{% alert color="primary" %}}
+This page contains release notes information for Aspose.HTML for .NET 26.6.
+{{% /alert %}}
+
+As per the regular monthly update process of all APIs being offered by Aspose, we are honored to announce the June release of Aspose.HTML for .NET.
+
+### Release Notes
+
+Aspose.HTML for .NET 26.6.0 is published as part of the June monthly release.
+
+**Package references**<br>
+Aspose.HTML for .NET 26.6.0 [NuGet](https://www.nuget.org/packages/Aspose.Html)<br>
+Aspose.HTML for Python via .NET  26.6.0 [PyPI](https://pypi.org/project/aspose-html-net/)
+
+## **Improvements and Changes**
+
+- Maintenance build for the June 26.6.0 release of Aspose.HTML for .NET.


### PR DESCRIPTION
Auto-generated release notes for HTML 26.6.0 (net).