### PR TITLE
Release notes (net): SVG 26.6.0

### DIFF
--- a/content/en/svg/net/release-notes/2026/aspose-svg-for-net-26.6.0-release-notes.md
+++ b/content/en/svg/net/release-notes/2026/aspose-svg-for-net-26.6.0-release-notes.md
@@ -1,0 +1,32 @@
+---
+id: "aspose-svg-for-net-26-6-release-notes"
+slug: "aspose-svg-for-net-26-6-release-notes"
+linktitle: "Aspose.SVG for .NET 26.6 Release Notes"
+title: "Aspose.SVG for .NET 26.6 Release Notes"
+weight: 45
+description: "Aspose.SVG for .NET 26.6 Release Notes - the latest updates and fixes."
+type: "repository"
+layout: "release"
+hideChildren: false
+toc: false
+family_listing_page_title: "Aspose.SVG for .NET 26.6 Release Notes"
+menuItemWithNoContent: false
+---
+
+{{% alert color="primary" %}}
+This page contains release notes information for Aspose.SVG for .NET 26.6.
+{{% /alert %}}
+
+As per the regular monthly update process of all APIs being offered by Aspose, we are honored to announce the June release of Aspose.SVG for .NET.
+
+### Release Notes
+
+Aspose.SVG for .NET 26.6.0 is published as part of the June monthly release.
+
+**Package references**<br>
+Aspose.SVG for .NET 26.6.0 [NuGet](https://www.nuget.org/packages/Aspose.Svg)<br>
+Aspose.SVG for Python via .NET  26.6.0 [PyPI](https://pypi.org/project/aspose-svg-net/)
+
+## **Improvements and Changes**
+
+- Maintenance build for the June 26.6.0 release of Aspose.SVG for .NET.

--- a/content/en/svg/net/release-notes/2026/aspose-svg-for-net-26.6.0-release-notes.md
+++ b/content/en/svg/net/release-notes/2026/aspose-svg-for-net-26.6.0-release-notes.md
@@ -30,3 +30,4 @@ Aspose.SVG for Python via .NET  26.6.0 [PyPI](https://pypi.org/project/aspose-sv
 ## **Improvements and Changes**
 
 - Maintenance build for the June 26.6.0 release of Aspose.SVG for .NET.
+- Fixed a stack overflow that could occur when processing documents with deeply nested elements.


### PR DESCRIPTION
Auto-generated release notes for SVG 26.6.0 (net).