### PR TITLE
Show compliance reports link on Java release pages

### DIFF
--- a/layouts/partials/repository/repo-pagelayout.html
+++ b/layouts/partials/repository/repo-pagelayout.html
@@ -193,6 +193,17 @@ implementation group: '{{ .groupId }}', name: '{{ .artifactId }}', classifier: '
                  </a>
               </li>
               {{ end }}
+              
+              {{ with .context.GetPage "compliance-reports" }}
+              <li role="presentation">
+                 <a href="{{ .RelPermalink }}" role="tab" id="compliance-reports-body-tab" class="body-tab"
+                    title="View SBOMs, Security Reports, and License Disclosures"
+                    target="_blank" rel="noopener">
+                 <i class="fa-clipboard fa" aria-hidden="true"></i>
+                 Compliance Reports
+                 </a>
+              </li>
+              {{ end }}
 
            </ul>
 


### PR DESCRIPTION
Mirrors PR #947 on the stage branch. Adds a Compliance Reports tab to the Java product pages (Java Merger Theme), shown only when the product has a compliance-reports section.
