### PR TITLE
feat(total): add Compliance Reports hub pages for Aspose.Total families

### DIFF
--- a/content/en/total/cpp/compliance-reports/_index.md
+++ b/content/en/total/cpp/compliance-reports/_index.md
@@ -1,0 +1,26 @@
+---
+id: "compliance-reports"
+linktitle: "Compliance Reports"
+title: "Compliance Reports"
+productName: "Aspose.Total for C++"
+weight: 99
+description: "Explore Aspose.Total for C++ compliance reports featuring SonarQube security analysis, SBOMs in CycloneDX and SPDX formats, and vulnerability assessments based on CWE Top 25 and OWASP Top 10, designed to support secure C++ development and regulatory transparency."
+type: "repository"
+layout: "release"
+hideChildren: false
+toc: false
+family_listing_page_title: "Compliance Reports"
+---
+
+| Product Family | Compliance Reports |
+|------------------------------------|---------------|
+| Aspose.Cells for C++ | [Compliance Reports](https://releases.aspose.com/cells/cpp/compliance-reports/) |
+| Aspose.Email for C++ | [Compliance Reports](https://releases.aspose.com/email/cpp/compliance-reports/) |
+| Aspose.Font for C++ | [Compliance Reports](https://releases.aspose.com/font/cpp/compliance-reports/) |
+| Aspose.Page for C++ | [Compliance Reports](https://releases.aspose.com/page/cpp/compliance-reports/) |
+| Aspose.PDF for C++ | [Compliance Reports](https://releases.aspose.com/pdf/cpp/compliance-reports/) |
+| Aspose.PUB for C++ | [Compliance Reports](https://releases.aspose.com/pub/cpp/compliance-reports/) |
+| Aspose.Slides for C++ | [Compliance Reports](https://releases.aspose.com/slides/cpp/compliance-reports/) |
+| Aspose.Tasks for C++ | [Compliance Reports](https://releases.aspose.com/tasks/cpp/compliance-reports/) |
+| Aspose.TeX for C++ | [Compliance Reports](https://releases.aspose.com/tex/cpp/compliance-reports/) |
+| Aspose.Words for C++ | [Compliance Reports](https://releases.aspose.com/words/cpp/compliance-reports/) |

--- a/content/en/total/java/compliance-reports/_index.md
+++ b/content/en/total/java/compliance-reports/_index.md
@@ -4,10 +4,35 @@ linktitle: "Compliance Reports"
 title: "Compliance Reports"
 productName: "Aspose.Total for Java"
 weight: 99
-description: "Explore Aspose.Total for Java compliance reports featuring SonarQube security analysis, SBOMs in CycloneDX and SPDX formats, and vulnerability assessments based on CWE Top 25 and OWASP Top 10—designed to support secure Java development and regulatory transparency."
+description: "Explore Aspose.Total for Java compliance reports featuring SonarQube security analysis, SBOMs in CycloneDX and SPDX formats, and vulnerability assessments based on CWE Top 25 and OWASP Top 10, designed to support secure Java development and regulatory transparency."
 type: "repository"
-layout: "releases"
+layout: "release"
 hideChildren: false
 toc: false
 family_listing_page_title: "Compliance Reports"
 ---
+
+| Product Family | Compliance Reports |
+|------------------------------------|---------------|
+| Aspose.3D for Java | [Compliance Reports](https://releases.aspose.com/3d/java/compliance-reports/) |
+| Aspose.BarCode for Java | [Compliance Reports](https://releases.aspose.com/barcode/java/compliance-reports/) |
+| Aspose.CAD for Java | [Compliance Reports](https://releases.aspose.com/cad/java/compliance-reports/) |
+| Aspose.Cells for Java | [Compliance Reports](https://releases.aspose.com/cells/java/compliance-reports/) |
+| Aspose.Diagram for Java | [Compliance Reports](https://releases.aspose.com/diagram/java/compliance-reports/) |
+| Aspose.Drawing for Java | [Compliance Reports](https://releases.aspose.com/drawing/java/compliance-reports/) |
+| Aspose.Email for Java | [Compliance Reports](https://releases.aspose.com/email/java/compliance-reports/) |
+| Aspose.Font for Java | [Compliance Reports](https://releases.aspose.com/font/java/compliance-reports/) |
+| Aspose.HTML for Java | [Compliance Reports](https://releases.aspose.com/html/java/compliance-reports/) |
+| Aspose.Imaging for Java | [Compliance Reports](https://releases.aspose.com/imaging/java/compliance-reports/) |
+| Aspose.Note for Java | [Compliance Reports](https://releases.aspose.com/note/java/compliance-reports/) |
+| Aspose.OCR for Java | [Compliance Reports](https://releases.aspose.com/ocr/java/compliance-reports/) |
+| Aspose.OMR for Java | [Compliance Reports](https://releases.aspose.com/omr/java/compliance-reports/) |
+| Aspose.Page for Java | [Compliance Reports](https://releases.aspose.com/page/java/compliance-reports/) |
+| Aspose.PDF for Java | [Compliance Reports](https://releases.aspose.com/pdf/java/compliance-reports/) |
+| Aspose.PSD for Java | [Compliance Reports](https://releases.aspose.com/psd/java/compliance-reports/) |
+| Aspose.PUB for Java | [Compliance Reports](https://releases.aspose.com/pub/java/compliance-reports/) |
+| Aspose.Slides for Java | [Compliance Reports](https://releases.aspose.com/slides/java/compliance-reports/) |
+| Aspose.Tasks for Java | [Compliance Reports](https://releases.aspose.com/tasks/java/compliance-reports/) |
+| Aspose.TeX for Java | [Compliance Reports](https://releases.aspose.com/tex/java/compliance-reports/) |
+| Aspose.Words for Java | [Compliance Reports](https://releases.aspose.com/words/java/compliance-reports/) |
+| Aspose.ZIP for Java | [Compliance Reports](https://releases.aspose.com/zip/java/compliance-reports/) |

--- a/content/en/total/net/compliance-reports/_index.md
+++ b/content/en/total/net/compliance-reports/_index.md
@@ -4,12 +4,39 @@ linktitle: "Compliance Reports"
 title: "Compliance Reports"
 productName: "Aspose.Total for .NET"
 weight: 99
-description: "Explore Aspose.Total for .NET compliance reports featuring SonarQube security analysis, SBOMs in CycloneDX and SPDX formats, and vulnerability assessments based on CWE Top 25 and OWASP Top 10—designed to support secure net development and regulatory transparency."
+description: "Explore Aspose.Total for .NET compliance reports featuring SonarQube security analysis, SBOMs in CycloneDX and SPDX formats, and vulnerability assessments based on CWE Top 25 and OWASP Top 10, designed to support secure .NET development and regulatory transparency."
 type: "repository"
-layout: "releases"
+layout: "release"
 hideChildren: false
 toc: false
 family_listing_page_title: "Compliance Reports"
-committed_by: "saud.naushahi@aspose.com"
 ---
 
+| Product Family | Compliance Reports |
+|------------------------------------|---------------|
+| Aspose.3D for .NET | [Compliance Reports](https://releases.aspose.com/3d/net/compliance-reports/) |
+| Aspose.BarCode for .NET | [Compliance Reports](https://releases.aspose.com/barcode/net/compliance-reports/) |
+| Aspose.CAD for .NET | [Compliance Reports](https://releases.aspose.com/cad/net/compliance-reports/) |
+| Aspose.Cells for .NET | [Compliance Reports](https://releases.aspose.com/cells/net/compliance-reports/) |
+| Aspose.Diagram for .NET | [Compliance Reports](https://releases.aspose.com/diagram/net/compliance-reports/) |
+| Aspose.Drawing for .NET | [Compliance Reports](https://releases.aspose.com/drawing/net/compliance-reports/) |
+| Aspose.Email for .NET | [Compliance Reports](https://releases.aspose.com/email/net/compliance-reports/) |
+| Aspose.Finance for .NET | [Compliance Reports](https://releases.aspose.com/finance/net/compliance-reports/) |
+| Aspose.Font for .NET | [Compliance Reports](https://releases.aspose.com/font/net/compliance-reports/) |
+| Aspose.GIS for .NET | [Compliance Reports](https://releases.aspose.com/gis/net/compliance-reports/) |
+| Aspose.HTML for .NET | [Compliance Reports](https://releases.aspose.com/html/net/compliance-reports/) |
+| Aspose.Imaging for .NET | [Compliance Reports](https://releases.aspose.com/imaging/net/compliance-reports/) |
+| Aspose.Medical for .NET | [Compliance Reports](https://releases.aspose.com/medical/net/compliance-reports/) |
+| Aspose.Note for .NET | [Compliance Reports](https://releases.aspose.com/note/net/compliance-reports/) |
+| Aspose.OCR for .NET | [Compliance Reports](https://releases.aspose.com/ocr/net/compliance-reports/) |
+| Aspose.OMR for .NET | [Compliance Reports](https://releases.aspose.com/omr/net/compliance-reports/) |
+| Aspose.Page for .NET | [Compliance Reports](https://releases.aspose.com/page/net/compliance-reports/) |
+| Aspose.PDF for .NET | [Compliance Reports](https://releases.aspose.com/pdf/net/compliance-reports/) |
+| Aspose.PSD for .NET | [Compliance Reports](https://releases.aspose.com/psd/net/compliance-reports/) |
+| Aspose.PUB for .NET | [Compliance Reports](https://releases.aspose.com/pub/net/compliance-reports/) |
+| Aspose.Slides for .NET | [Compliance Reports](https://releases.aspose.com/slides/net/compliance-reports/) |
+| Aspose.SVG for .NET | [Compliance Reports](https://releases.aspose.com/svg/net/compliance-reports/) |
+| Aspose.Tasks for .NET | [Compliance Reports](https://releases.aspose.com/tasks/net/compliance-reports/) |
+| Aspose.TeX for .NET | [Compliance Reports](https://releases.aspose.com/tex/net/compliance-reports/) |
+| Aspose.Words for .NET | [Compliance Reports](https://releases.aspose.com/words/net/compliance-reports/) |
+| Aspose.ZIP for .NET | [Compliance Reports](https://releases.aspose.com/zip/net/compliance-reports/) |


### PR DESCRIPTION
Adds a Compliance Reports landing page for the Aspose.Total families that have per product
compliance reports, formatted like the existing Release Notes hub pages: a flat two column
table of links.

| Page | Rows | Change |
|---|---|---|
| /total/net/compliance-reports/ | 26 | replaces existing page |
| /total/java/compliance-reports/ | 22 | replaces existing page |
| /total/cpp/compliance-reports/ | 10 | new page |

Scope

Row membership and order come from each platform's existing release-notes/_index.md table,
intersected with compliance report availability from https://releases.aspose.com/index.json.
All 58 linked URLs return HTTP 200 and were each confirmed to have at least one published
report behind them. Tables are alphabetical.

Two deliberate scope decisions:

* Aspose.Medical for .NET is included on the net page. It has a live compliance reports page
  and is already a row in the existing aspose-total-for-net-25-4-compliance-reports.md matrix,
  although it is absent from the .NET release notes table.
* No page for Python via .NET. index.json advertises Cells and SVG, but both compliance
  sections contain only _index.md with no report pages, so a hub page there would dead end.
  To be added once those products publish real reports.

Behaviour change on net and java

Both pages move from layout "releases" to layout "release". The "releases" layout paginates
child pages and never renders page content, so a table placed in it would be invisible.
Consequence: the child listing "Compliance Reports - 2025 -> Read More" is replaced by the
table. The 2025 bundle pages are untouched and keep their URLs, they are simply no longer
enumerated from the hub page. Reviewed and accepted.

The unused committed_by front matter key is dropped from the net page. No template in
layouts/ or the theme reads it, and the java page never carried it.

Entry points

No template change is needed. The C++ product page already calls the Common/release-notes-link
shortcode, whose final block is guarded by site.GetPage "<family>/<product>/compliance-reports",
so the Compliance Reports button appears on /total/cpp/ as soon as the page exists. Java uses
the tab strip in repo-pagelayout.html, which already carries the guarded tab. The .NET button
is unchanged.

Build impact

Content only, under content/en/total/**, so this matches prod-build-total.yml and does not
match releases-aspose-com-prod.yml. The trimmed total family build runs, not the full site
build, and it performs its own CloudFront invalidation.

Verified on stage

Merged as #951. The staging-total run succeeded in 2m 11s and the full site workflow did not
fire. Live on releases-qa.aspose.com with 26, 22 and 10 rows, alphabetical order, and the
Compliance Reports button present on /total/cpp/.
