### PR TITLE
Release notes (net): HTML 26.8.0

### DIFF
--- a/content/en/html/net/release-notes/2026/aspose-html-for-net-26.8.0-release-notes.md
+++ b/content/en/html/net/release-notes/2026/aspose-html-for-net-26.8.0-release-notes.md
@@ -21,7 +21,7 @@ As per the regular monthly update process of all APIs being offered by Aspose, w
 
 ### Release Notes
 
-Aspose.HTML for .NET 26.8.0 is published as part of the August monthly release.
+This release fixes issues with rendering and layout, including looping when paginating and problems with rendering tables. Support for javascript libraries for drawing graphs has also been improved (Highcharts/Highstock and Chart.js ).
 
 **Package references**<br>
 Aspose.HTML for .NET 26.8.0 [NuGet](https://www.nuget.org/packages/Aspose.Html)<br>
@@ -29,4 +29,71 @@ Aspose.HTML for Python via .NET  26.8.0 [PyPI](https://pypi.org/project/aspose-h
 
 ## **Improvements and Changes**
 
-- Maintenance build for the August 26.8.0 release of Aspose.HTML for .NET.
+| **Key** | **Summary** | **Category** |
+| ------------ | -------------------------------------------------------------------------------------- | ------------ |
+| HTMLNET-3325| HTML to PNG - Rows of HTML Table are missing in the output | Bug |
+| HTMLNET-7180 | PageSetup.FirstPage.Margins is ignored when AtPagePriority is set to CssPriority | Bug |
+| HTMLNET-7181 | HTML to PDF: Table with two tbody elements causes runaway memory | Bug |
+| HTMLNET-6361 | Incorrect Output Converting HTML to PNG. | Bug |
+| HTMLNET-7198 | Empty page at the beginning of the converted document. | Bug |
+| HTMLNET-7190 | HTML-to-PDF content splits onto a second page | Bug |
+
+## Public API and Backward Incompatible Changes
+
+### Added APIs
+
+```
+namespace Aspose.Html.Dom
+{
+    /// <summary>
+    /// The Element interface represents an element in an HTML or XML document.
+    /// </summary>
+    public class Element : Node
+    {
+        /// <summary>
+        /// Returns the closest ancestor element (or the element itself) that matches the specified CSS selector.
+        /// </summary>
+        /// <param name="selector">The selector.</param>
+        /// <returns>The closest matching element; otherwise, <c>null</c>.</returns>
+        public Element Closest(string selectors)
+        {
+        }
+
+        /// <summary>
+        /// Determines whether the element matches the specified CSS selector.
+        /// </summary>
+        /// <param name="selector">The selector.</param>
+        /// <returns><c>true</c> if the element matches the selector; otherwise, <c>false</c>.</returns>
+        public bool Matches(string selectors)
+        {
+        }
+    }
+}
+
+namespace Aspose.Html
+{
+    /// <summary>
+    /// The HTMLElement interface represents any HTML element.
+    /// </summary>
+    public class HTMLElement : Element
+    {
+        /// <summary>
+        /// Gets the layout height of the element in pixels.
+        /// </summary>
+        /// <value>
+        /// The height of the element in pixels. If the height cannot be determined,
+        /// returns <c>0</c>.
+        /// </value>
+        public int OffsetHeight { get; }
+
+        /// <summary>
+        /// Gets the layout width of the element in pixels.
+        /// </summary>
+        /// <value>
+        /// The width of the element in pixels. If the width cannot be determined,
+        /// returns <c>0</c>.
+        /// </value>
+        public int OffsetWidth { get; }
+    }
+}
+```

--- a/content/en/html/net/release-notes/2026/aspose-html-for-net-26.8.0-release-notes.md
+++ b/content/en/html/net/release-notes/2026/aspose-html-for-net-26.8.0-release-notes.md
@@ -1,0 +1,32 @@
+---
+id: "aspose-html-for-net-26-8-release-notes"
+slug: "aspose-html-for-net-26-8-release-notes"
+linktitle: "Aspose.HTML for .NET 26.8 Release Notes"
+title: "Aspose.HTML for .NET 26.8 Release Notes"
+weight: 50
+description: "Aspose.HTML for .NET 26.8 Release Notes - the latest updates and fixes."
+type: "repository"
+layout: "release"
+hideChildren: false
+toc: false
+family_listing_page_title: "Aspose.HTML for .NET 26.8 Release Notes"
+menuItemWithNoContent: false
+---
+
+{{% alert color="primary" %}}
+This page contains release notes information for Aspose.HTML for .NET 26.8.
+{{% /alert %}}
+
+As per the regular monthly update process of all APIs being offered by Aspose, we are honored to announce the August release of Aspose.HTML for .NET.
+
+### Release Notes
+
+Aspose.HTML for .NET 26.8.0 is published as part of the August monthly release.
+
+**Package references**<br>
+Aspose.HTML for .NET 26.8.0 [NuGet](https://www.nuget.org/packages/Aspose.Html)<br>
+Aspose.HTML for Python via .NET  26.8.0 [PyPI](https://pypi.org/project/aspose-html-net/)
+
+## **Improvements and Changes**
+
+- Maintenance build for the August 26.8.0 release of Aspose.HTML for .NET.

--- a/content/en/html/python-net/release-notes/2026/aspose-html-for-python-via-dotnet-26.8.0-release-notes.md
+++ b/content/en/html/python-net/release-notes/2026/aspose-html-for-python-via-dotnet-26.8.0-release-notes.md
@@ -1,0 +1,52 @@
+---
+id: "aspose-html-for-python-via-dotnet-26-8-release-notes"
+slug: "aspose-html-for-python-via-dotnet-26-8-release-notes"
+linktitle: "Aspose.HTML for Python via .NET 26.8 Release Notes"
+title: "Aspose.HTML for Python via .NET 26.8 Release Notes"
+weight: 50
+description: "Aspose.HTML for Python via .NET 26.8 Release Notes - the latest updates and fixes."
+type: "repository"
+layout: "release"
+hideChildren: false
+toc: false
+family_listing_page_title: "Aspose.HTML for Python via .NET 26.8 Release Notes"
+menuItemWithNoContent: false
+---
+
+{{% alert color="primary" %}}
+This page contains release notes information for Aspose.HTML for Python via .NET 26.8.
+{{% /alert %}}
+
+As per the regular monthly update process of all APIs being offered by Aspose, we are honored to announce the August release of Aspose.HTML for Python via .NET.
+
+### Release Notes
+
+In this release, the conversion to PDF with tag support has been improved, and the alignment of the grid layout has been improved. The API for working with attachments in MHTML format has also been expanded, and attributes of text elements in SVG format have been fixed. In addition, this release includes numerous improvements to the rendering engine when calculating the layout for blocks, tables, flexbox, and grid layouts.
+
+**Package references**<br>
+Aspose.HTML for Python via .NET 26.8.0 [NuGet](https://www.nuget.org/packages/Aspose.Html)<br>
+Aspose.HTML.Drawing for .NET 26.8.0 [NuGet](https://www.nuget.org/packages/Aspose.Html.Drawing)<br>
+Aspose.HTML for Python via .NET  26.8.0 [PyPI](https://pypi.org/project/aspose-html-net/)
+
+## **Improvements and Changes**
+
+| **Key** | **Summary** | **Category** |
+| ------------ | -------------------------------------------------------------------------------------- | ------------ |
+| HTMLNET-3325| HTML to PNG - Rows of HTML Table are missing in the output | Bug |
+| HTMLNET-7180 | PageSetup.FirstPage.Margins is ignored when AtPagePriority is set to CssPriority | Bug |
+| HTMLNET-7181 | HTML to PDF: Table with two tbody elements causes runaway memory | Bug |
+| HTMLNET-6361 | Incorrect Output Converting HTML to PNG. | Bug |
+| HTMLNET-7198 | Empty page at the beginning of the converted document. | Bug |
+| HTMLNET-7190 | HTML-to-PDF content splits onto a second page | Bug |
+
+## **Public API Changes**
+
+### **Added APIs**
+
+| Module / Class | Member |
+|----------------|--------|
+| `aspose.html.dom.Element` | `.closest(selectors)` method |
+| `aspose.html.dom.Element` | `.matches(selectors)` method |
+| `aspose.html.HTMLElement` | `.offset_height` property |
+| `aspose.html.HTMLElement` | `.offset_width` property |
+


### PR DESCRIPTION
Auto-generated release notes for HTML 26.8.0 (net).